### PR TITLE
added toolchain and libXaw as dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ build:
 
 requirements:
   build:
+    - toolchain
     - libxml2
     - ncurses 5.9*
     - dbus  # [osx]
@@ -28,6 +29,7 @@ requirements:
     - libtiff 4.0.*
     - giflib 5.1.*
     - freetype 2.6.*  # [linux]
+    - xorg-libxaw  # [linux]
   run:
     - libxml2
     - ncurses 5.9*
@@ -37,6 +39,7 @@ requirements:
     - libtiff 4.0.*
     - giflib 5.1.*
     - freetype 2.6.*  # [linux]
+    - xorg-libxaw  # [linux]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,4 +63,3 @@ extra:
     - asmeurer
     - msarahan
     - notestaff
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha1: 3960d0b64031c645d98aafd4dc9ebf6f6ef4cf50
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   detect_binary_files_with_prefix: true
 
@@ -62,3 +62,5 @@ extra:
   recipe-maintainers:
     - asmeurer
     - msarahan
+    - notestaff
+

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,1 +1,0 @@
-libXaw-devel


### PR DESCRIPTION
added toolchain and libXaw as dependencies (without the latter conda-build fails on linux).