### PR TITLE
Make emacs a shell script on OS X

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,8 +17,11 @@ make install
 if [ "$(uname)" == "Darwin" ]; then
     mv nextstep/Emacs.app $PREFIX/Emacs.app
     mkdir -p $PREFIX/bin
-    ln -s $PREFIX/Emacs.app/Contents/MacOS/Emacs $PREFIX/bin/emacs-25.1
-    ln -s $PREFIX/bin/emacs-25.1 $PREFIX/bin/emacs
+    cat <<EOF > $PREFIX/bin/emacs-$PKG_VERSION
+#!/bin/sh
+$PREFIX/Emacs.app/Contents/MacOS/Emacs "\$@"
+EOF
+    ln -s $PREFIX/bin/emacs-$PKG_VERSION $PREFIX/bin/emacs
     ln -s $PREFIX/Emacs.app/Contents/MacOS/bin/ctags $PREFIX/bin/ctags
     ln -s $PREFIX/Emacs.app/Contents/MacOS/bin/ebrowse $PREFIX/bin/ebrowse
     ln -s $PREFIX/Emacs.app/Contents/MacOS/bin/emacsclient $PREFIX/bin/emacsclient

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,6 +21,7 @@ if [ "$(uname)" == "Darwin" ]; then
 #!/bin/sh
 $PREFIX/Emacs.app/Contents/MacOS/Emacs "\$@"
 EOF
+    chmod a+x $PREFIX/bin/emacs-$PKG_VERSION
     ln -s $PREFIX/bin/emacs-$PKG_VERSION $PREFIX/bin/emacs
     ln -s $PREFIX/Emacs.app/Contents/MacOS/bin/ctags $PREFIX/bin/ctags
     ln -s $PREFIX/Emacs.app/Contents/MacOS/bin/ebrowse $PREFIX/bin/ebrowse

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha1: 1cb4f39e9c0a3305fd62f936c7c95ff8e2924323
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   detect_binary_files_with_prefix: true
 


### PR DESCRIPTION
This makes it launch the GUI correctly. See
https://stackoverflow.com/questions/10171280/how-to-launch-gui-emacs-from-command-line-in-osx.

The (x-focus-frame nil) part didn't seem necessary for me to make emacs go in
front of the terminal. But if it becomes a problem, it should be possible to
add that to the command line options of emacs.