### PR TITLE
Build emacs with native compilation

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,7 +11,7 @@ if [ "$(uname)" == "Darwin" ]; then
     # https://github.com/conda-forge/emacs-feedstock/pull/16#issuecomment-334241528
     export LDFLAGS="${LDFLAGS} -ltinfo"
 else
-    OPTS="--x-includes=$PREFIX/include --x-libraries=$PREFIX/lib --with-x-toolkit=gtk3 --with-harfbuzz -with-cairo --with-tree-sitter --with-json"
+    OPTS="--x-includes=$PREFIX/include --x-libraries=$PREFIX/lib --with-x-toolkit=gtk3 --with-harfbuzz -with-cairo --with-tree-sitter --with-json --with-native-compilation"
 fi
 
 autoreconf -vfi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - 0007-macos-cross-compile-lisp-makefile.patch  # [osx and build_platform != target_platform]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   detect_binary_files_with_prefix: true
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ requirements:
     - zlib  # [build_platform != target_platform]
     - libtree-sitter
     - jansson
+    - gcc  # [linux]
 
   host:
     - libxml2
@@ -82,6 +83,7 @@ requirements:
     - zlib
     - libtree-sitter
     - jansson
+    - gcc  # [linux]
 
   run:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
@@ -114,6 +116,7 @@ requirements:
     - zlib
     - libtree-sitter
     - jansson
+    - gcc  # [linux]
 
 test:
   commands:
@@ -128,6 +131,8 @@ test:
     - $PREFIX/bin/emacs --batch --eval '(unless (treesit-available-p) (kill-emacs 1))'
     # Make sure json works
     - $PREFIX/bin/emacs --batch --eval '(unless (json-available-p) (kill-emacs 1))'
+    # Make sure native compilation works
+    - $PREFIX/bin/emacs --batch --eval '(unless (native-comp-available-p) (kill-emacs 1))'  # [linux]
 
 about:
   home: http://www.gnu.org/software/emacs/


### PR DESCRIPTION
This is linux-only because conda-forge doesn't have a gcc package for macos.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Fixes https://github.com/conda-forge/emacs-feedstock/issues/59