### PR TITLE
Build with native compilation support

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,6 +6,10 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
 cairo:
 - '1'
 cdt_name:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,7 @@
 set -x
 
+source $RECIPE_DIR/get_cpu_arch.sh
+
 # Get an updated config.sub and config.guess
 cp $BUILD_PREFIX/share/gnuconfig/config.* ./build-aux
 
@@ -11,6 +13,64 @@ if [ "$(uname)" == "Darwin" ]; then
     # https://github.com/conda-forge/emacs-feedstock/pull/16#issuecomment-334241528
     export LDFLAGS="${LDFLAGS} -ltinfo"
 else
+    # Build libgccjit for the native compilation
+    mkdir gcc-jit
+    pushd gcc-jit
+    ../gcc/configure \
+        --host=$HOST \
+        --target=$HOST \
+        --enable-host-shared \
+        --enable-languages=jit \
+        --disable-bootstrap \
+        --disable-multilib \
+        --enable-libquadmath \
+        --enable-libquadmath-support \
+        --enable-long-long \
+        --disable-libgomp \
+        --without-isl \
+        --disable-libssp \
+        --disable-libmudflap \
+        --disable-nls \
+        --with-build-sysroot=${CONDA_BUILD_SYSROOT} \
+        --with-sysroot=${PREFIX}/${HOST}/sysroot \
+        --prefix=$PREFIX/lib/emacs/jit
+    make -j"${CPU_COUNT}"
+    make install-strip
+
+    # ${HOST}-gcc-${GCCJIT_VERSION} needs to be in $PATH to make
+    # libgccjit work
+    GCCJIT_PREFIX=${PREFIX}/lib/emacs/jit
+    GCCJIT_VERSION=$(${GCCJIT_PREFIX}/bin/gcc -dumpversion)
+
+    rm -rf "${GCCJIT_PREFIX}"/libexec
+    rm -rf "${GCCJIT_PREFIX}"/share
+    rm -rf "${GCCJIT_PREFIX}"/lib/gcc/${HOST}/${GCCJIT_VERSION}/include
+    rm -rf "${GCCJIT_PREFIX}"/lib/gcc/${HOST}/${GCCJIT_VERSION}/include-fixed
+    rm -rf "${GCCJIT_PREFIX}"/lib/gcc/${HOST}/${GCCJIT_VERSION}/plugin
+
+    for FN in "${GCCJIT_PREFIX}"/bin/* ; do
+        if [[ $FN == "${GCCJIT_PREFIX}"/bin/${HOST}-gcc-${GCCJIT_VERSION} ]] ; then
+            cp -s "$FN" "$PREFIX"/bin/
+        else
+            rm "$FN"
+        fi
+    done
+
+    # Generate and install the GCC specs file
+    SPECSFILE=${PREFIX}/lib/emacs/jit/lib/gcc/${HOST}/${GCCJIT_VERSION}/specs
+    ${PREFIX}/bin/${HOST}-gcc-${GCCJIT_VERSION} -dumpspecs > ${SPECSFILE}
+
+    # Point the sysroot and C runtime object paths to the Conda
+    # sysroot
+    cat ${SPECSFILE} | sed -E "\
+s@:crt1.o@:${PREFIX}/${HOST}/sysroot/usr/lib/crt1.o@g
+s@ crti.o@ ${PREFIX}/${HOST}/sysroot/usr/lib/crti.o@g
+s@ crtn.o@ ${PREFIX}/${HOST}/sysroot/usr/lib/crtn.o@g
+s@--sysroot=%R@--sysroot=${PREFIX}/${HOST}/sysroot@g
+" > ${SPECSFILE}.new
+    mv ${SPECSFILE}.new ${SPECSFILE}
+    popd
+
     OPTS="--x-includes=$PREFIX/include --x-libraries=$PREFIX/lib --with-x-toolkit=gtk3 --with-harfbuzz -with-cairo --with-tree-sitter --with-json"
 fi
 
@@ -30,7 +90,7 @@ if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 ]]; then
     export host_alias=$build_alias
 
     bash ../configure --with-modules --prefix=$BUILD_PREFIX $OPTS
-    make V=1
+    make -j"${CPU_COUNT}" V=1
 
     popd
   )
@@ -45,9 +105,15 @@ if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 ]]; then
   OPTS="$OPTS --with-pdumper=yes --with-unexec=no --with-dumping=none"
 fi
 
+if [ "$(uname)" != "Darwin" ]; then
+    CFLAGS="$CFLAGS -I$PREFIX/lib/emacs/jit/include"
+    LDFLAGS="$LDFLAGS -L$PREFIX/lib/emacs/jit/lib -Wl,-rpath,$PREFIX/lib/emacs/jit/lib"
+    OPTS="$OPTS --with-native-compilation=yes"
+fi
+
 bash configure --with-modules --prefix=$PREFIX $OPTS
 
-make V=1
+make -j"${CPU_COUNT}" V=1
 
 # make check
 make install
@@ -66,7 +132,7 @@ EOF
     ln -s $PREFIX/Emacs.app/Contents/MacOS/bin/emacsclient $PREFIX/bin/emacsclient
     ln -s $PREFIX/Emacs.app/Contents/MacOS/bin/etags $PREFIX/bin/etags
     if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 ]]; then
-	# Make an empty pdump file as a sentinel to post-link.sh
+        # Make an empty pdump file as a sentinel to post-link.sh
         touch $PREFIX/Emacs.app/Contents/MacOS/libexec/Emacs.pdmp
     fi
 fi

--- a/recipe/get_cpu_arch.sh
+++ b/recipe/get_cpu_arch.sh
@@ -1,0 +1,34 @@
+get_cpu_arch() {
+  local CPU_ARCH
+  if [[ "$1" == *"-64" ]]; then
+    CPU_ARCH="x86_64"
+  elif [[ "$1" == *"-ppc64le" ]]; then
+    CPU_ARCH="powerpc64le"
+  elif [[ "$1" == *"-aarch64" ]]; then
+    CPU_ARCH="aarch64"
+  elif [[ "$1" == *"-s390x" ]]; then
+    CPU_ARCH="s390x"
+  else
+    echo "Unknown architecture"
+    exit 1
+  fi
+  echo $CPU_ARCH
+}
+
+get_triplet() {
+  if [[ "$1" == linux-* ]]; then
+    echo "$(get_cpu_arch $1)-conda-linux-gnu"
+  elif [[ "$1" == osx-64 ]]; then
+    echo "x86_64-apple-darwin13.4.0"
+  elif [[ "$1" == osx-arm64 ]]; then
+    echo "arm64-apple-darwin20.0.0"
+  elif [[ "$1" == win-64 ]]; then
+    echo "x86_64-w64-mingw32"
+  else
+    echo "unknown platform"
+    exit 1
+  fi
+}
+
+export BUILD="$(get_triplet $build_platform)"
+export HOST="$(get_triplet $target_platform)"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,33 +2,43 @@
 
 {% set version = "29.3" %}
 
+# Version of GCC sources used to build the embedded JIT compiler
+{% set gcc_version = "14.2.0" %}
+
 package:
   name: emacs
   version: {{ version }}
 
 source:
-  fn: emacs-{{ version }}.tar.xz
-  url: http://ftp.gnu.org/gnu/emacs/emacs-{{ version }}.tar.xz
-  sha256: c34c05d3ace666ed9c7f7a0faf070fea3217ff1910d004499bd5453233d742a0
-  patches:
-    - 0001-disable-sanity-check.patch  # [osx and build_platform != target_platform]
-    - 0002-apple-silicon-resign-binary.patch  # [osx]
-    - 0003-macos-cross-compile-configure.patch  # [osx and build_platform != target_platform]
-    - 0004-macos-cross-compile-makefile.patch  # [osx and build_platform != target_platform]
-    - 0005-macos-cross-compile-nextstep-makefile.patch  # [osx and build_platform != target_platform]
-    - 0006-macos-cross-compile-post-install-pdump-path.patch  # [osx and build_platform != target_platform]
-    - 0007-macos-cross-compile-lisp-makefile.patch  # [osx and build_platform != target_platform]
+  - fn: emacs-{{ version }}.tar.xz
+    url: http://ftp.gnu.org/gnu/emacs/emacs-{{ version }}.tar.xz
+    sha256: c34c05d3ace666ed9c7f7a0faf070fea3217ff1910d004499bd5453233d742a0
+    patches:
+      - 0001-disable-sanity-check.patch  # [osx and build_platform != target_platform]
+      - 0002-apple-silicon-resign-binary.patch  # [osx]
+      - 0003-macos-cross-compile-configure.patch  # [osx and build_platform != target_platform]
+      - 0004-macos-cross-compile-makefile.patch  # [osx and build_platform != target_platform]
+      - 0005-macos-cross-compile-nextstep-makefile.patch  # [osx and build_platform != target_platform]
+      - 0006-macos-cross-compile-post-install-pdump-path.patch  # [osx and build_platform != target_platform]
+      - 0007-macos-cross-compile-lisp-makefile.patch  # [osx and build_platform != target_platform]
+  - fn: gcc-{{ gcc_version }}.tar.xz  # [linux]
+    url: https://ftp.gnu.org/gnu/gcc/gcc-{{ gcc_version }}/gcc-{{ gcc_version }}.tar.xz  # [linux]
+    sha256: a7b39bc69cbf9e25826c5a60ab26477001f7c08d85cec04bc0e29cabed6f3cc9  # [linux]
+    folder: gcc  # [linux]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
-  detect_binary_files_with_prefix: true
+  ignore_prefix_files:
+    - lib/emacs/jit/bin/*
+    - lib/emacs/jit/lib/*
 
 requirements:
   build:
     - pkg-config
     - gnuconfig  # [unix]
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}  # [linux]
     - {{ stdlib("c") }}
     - autoconf  # [unix]
     - automake  # [unix]
@@ -48,20 +58,27 @@ requirements:
     - gmp  # [build_platform != target_platform]
     - glib  # [build_platform != target_platform]
     - zlib  # [build_platform != target_platform]
+    - liblzma-devel
     - libtree-sitter
     - jansson
+    - texinfo
 
   host:
+    - {{ stdlib("c") }}  # [linux]
+    - binutils  # [linux]
     - libxml2
     - ncurses
     - dbus  # [osx]
     - libjpeg-turbo
     - libpng
     - libtiff
+    - liblzma-devel
     - librsvg
     - giflib
     - gnutls
     - gmp
+    - mpc  # [linux]
+    - mpfr  # [linux]
     - glib
     - freetype  # [linux]
     - cairo  # [linux]
@@ -77,13 +94,14 @@ requirements:
     - xorg-libxcomposite  # [linux]
     - xorg-libxdamage  # [linux]
     - xorg-libxinerama  # [linux]
-    - xorg-xineramaproto  # [linux]
+    - xorg-xorgproto  # [linux]
     - xorg-libxtst  # [linux]
     - zlib
     - libtree-sitter
     - jansson
 
   run:
+    - binutils  # [linux]
     - libxml2
     - ncurses
     - dbus  # [osx]
@@ -108,7 +126,7 @@ requirements:
     - xorg-libxcomposite  # [linux]
     - xorg-libxdamage  # [linux]
     - xorg-libxinerama  # [linux]
-    - xorg-xineramaproto  # [linux]
+    - xorg-xorgproto  # [linux]
     - xorg-libxtst  # [linux]
     - zlib
     - libtree-sitter
@@ -127,6 +145,7 @@ test:
     - $PREFIX/bin/emacs --batch --eval '(unless (treesit-available-p) (kill-emacs 1))'
     # Make sure json works
     - $PREFIX/bin/emacs --batch --eval '(unless (json-available-p) (kill-emacs 1))'
+    - $PREFIX/bin/emacs --batch --eval '(batch-native-compile t)' $PREFIX/share/emacs/{{ version }}/lisp/calculator.elc  # [linux]
 
 about:
   home: http://www.gnu.org/software/emacs/
@@ -137,5 +156,6 @@ about:
 extra:
   recipe-maintainers:
     - asmeurer
+    - jmakovicka
     - msarahan
     - notestaff


### PR DESCRIPTION
Ship with libgccjit in lib/emacs/jit

--

As including libgccjit in gcc feedstock seems unlikely, I added libgccjit directly to emacs. This is a bit dirty solution, and significantly increases the package size. On the other hand, this way emacs does not require a particular gcc version like it would with the proper gccjit-in-gcc-package approach, which is handy for C/C++ development.

I am using this build now on linux64, did not test the cross compilation yet (so it probably does not work).