### PR TITLE
Fix configure-info-directory corruption on Linux

### DIFF
--- a/recipe/0008-do-not-dump-configure-info-directory.patch
+++ b/recipe/0008-do-not-dump-configure-info-directory.patch
@@ -1,0 +1,47 @@
+From fea646d563254bb2b4082501fc765c11645fec85 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jind=C5=99ich=20Makovi=C4=8Dka?= <makovick@gmail.com>
+Date: Thu, 9 Jan 2025 20:59:11 +0100
+Subject: [PATCH] do not dump configure-info-directory
+
+Patching dumped configure-info-directory during conda install will not
+update the dumped string length. This results in a string with trailing
+padding zeros.
+
+epaths_path_info with global linkage prevents compile time strlen().
+---
+ src/callproc.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/callproc.c b/src/callproc.c
+index a3d34d55d53..a64cb4fd4d3 100644
+--- a/src/callproc.c
++++ b/src/callproc.c
+@@ -1946,6 +1946,8 @@ make_environment_block (Lisp_Object current_dir)
+ 
+ /* This is run before init_cmdargs.  */
+ 
++const char* epaths_path_info = PATH_INFO;
++
+ void
+ init_callproc_1 (void)
+ {
+@@ -1961,6 +1963,8 @@ init_callproc_1 (void)
+   Vexec_directory = Ffile_name_as_directory (Fcar (Vexec_path));
+   /* FIXME?  For ns, path_exec should go at the front?  */
+   Vexec_path = nconc2 (decode_env_path ("PATH", "", 0), Vexec_path);
++
++  Vconfigure_info_directory = build_string (epaths_path_info);
+ }
+ 
+ /* This is run after init_cmdargs, when Vinstallation_directory is valid.  */
+@@ -2131,7 +2135,6 @@ syms_of_callproc (void)
+ This is the name of the directory in which the build procedure installed
+ Emacs's info files; the default value for `Info-default-directory-list'
+ includes this.  */);
+-  Vconfigure_info_directory = build_string (PATH_INFO);
+ 
+   DEFVAR_LISP ("shared-game-score-directory", Vshared_game_score_directory,
+ 	       doc: /* Directory of score files for games which come with GNU Emacs.
+-- 
+2.47.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,13 +21,14 @@ source:
       - 0005-macos-add-missing-pdump-check.patch  # [osx and build_platform != target_platform]
       - 0006-macos-cross-compile-post-install-pdump-path.patch  # [osx and build_platform != target_platform]
       - 0007-macos-cross-compile-lisp-makefile.patch  # [osx and build_platform != target_platform]
+      - 0008-do-not-dump-configure-info-directory.patch  # [linux]
   - fn: gcc-{{ gcc_version }}.tar.xz  # [linux]
     url: https://ftp.gnu.org/gnu/gcc/gcc-{{ gcc_version }}/gcc-{{ gcc_version }}.tar.xz  # [linux]
     sha256: a7b39bc69cbf9e25826c5a60ab26477001f7c08d85cec04bc0e29cabed6f3cc9  # [linux]
     folder: gcc  # [linux]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   ignore_prefix_files:
     - lib/emacs/jit/bin/*
@@ -145,6 +146,8 @@ test:
     - $PREFIX/bin/emacs --batch --eval '(unless (treesit-available-p) (kill-emacs 1))'
     # Make sure json works
     - $PREFIX/bin/emacs --batch --eval '(unless (json-available-p) (kill-emacs 1))'
+    # Check the configure-info-directory patching
+    - $PREFIX/bin/emacs --batch --eval "(unless (string= \"${PREFIX}/share/info\" configure-info-directory) (kill-emacs 1))"  # [linux]
     - $PREFIX/bin/emacs --batch --eval '(batch-native-compile t)' $PREFIX/share/emacs/{{ version }}/lisp/calculator.elc  # [linux]
 
 about:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
