### PR TITLE
Rebuild for harfbuzz 10 and pin libtree-sitter to 0.24.*

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -31,7 +31,7 @@ gmp:
 gnutls:
 - '3.8'
 harfbuzz:
-- '9'
+- '10'
 libjpeg_turbo:
 - '3'
 liblzma_devel:

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ requirements:
     - glib  # [build_platform != target_platform]
     - zlib  # [build_platform != target_platform]
     - liblzma-devel
-    - libtree-sitter
+    - libtree-sitter 24.*  # https://github.com/conda-forge/libtree-sitter-feedstock/issues/25
     - jansson
     - texinfo
 
@@ -97,7 +97,7 @@ requirements:
     - xorg-xorgproto  # [linux]
     - xorg-libxtst  # [linux]
     - zlib
-    - libtree-sitter 24.*
+    - libtree-sitter 24.*  # https://github.com/conda-forge/libtree-sitter-feedstock/issues/25
     - jansson
 
   run:
@@ -129,7 +129,7 @@ requirements:
     - xorg-xorgproto  # [linux]
     - xorg-libxtst  # [linux]
     - zlib
-    - libtree-sitter
+    - libtree-sitter 24.*  # https://github.com/conda-forge/libtree-sitter-feedstock/issues/25
     - jansson
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ requirements:
     - glib  # [build_platform != target_platform]
     - zlib  # [build_platform != target_platform]
     - liblzma-devel
-    - libtree-sitter 24.*  # https://github.com/conda-forge/libtree-sitter-feedstock/issues/25
+    - libtree-sitter 0.24.*  # https://github.com/conda-forge/libtree-sitter-feedstock/issues/25
     - jansson
     - texinfo
 
@@ -97,7 +97,7 @@ requirements:
     - xorg-xorgproto  # [linux]
     - xorg-libxtst  # [linux]
     - zlib
-    - libtree-sitter 24.*  # https://github.com/conda-forge/libtree-sitter-feedstock/issues/25
+    - libtree-sitter 0.24.*  # https://github.com/conda-forge/libtree-sitter-feedstock/issues/25
     - jansson
 
   run:
@@ -129,7 +129,7 @@ requirements:
     - xorg-xorgproto  # [linux]
     - xorg-libxtst  # [linux]
     - zlib
-    - libtree-sitter 24.*  # https://github.com/conda-forge/libtree-sitter-feedstock/issues/25
+    - libtree-sitter 0.24.*  # https://github.com/conda-forge/libtree-sitter-feedstock/issues/25
     - jansson
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
     folder: gcc  # [linux]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   ignore_prefix_files:
     - lib/emacs/jit/bin/*
@@ -97,7 +97,7 @@ requirements:
     - xorg-xorgproto  # [linux]
     - xorg-libxtst  # [linux]
     - zlib
-    - libtree-sitter
+    - libtree-sitter 24.*
     - jansson
 
   run:


### PR DESCRIPTION
https://github.com/conda-forge/libtree-sitter-feedstock/issues/25

Closes https://github.com/conda-forge/emacs-feedstock/pull/97

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
