### PR TITLE
Revert the libtree-sitter pinnings

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
     folder: gcc  # [linux]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   ignore_prefix_files:
     - lib/emacs/jit/bin/*
@@ -59,7 +59,7 @@ requirements:
     - glib  # [build_platform != target_platform]
     - zlib  # [build_platform != target_platform]
     - liblzma-devel
-    - libtree-sitter 0.24.*  # https://github.com/conda-forge/libtree-sitter-feedstock/issues/25
+    - libtree-sitter
     - jansson
     - texinfo
 
@@ -97,7 +97,7 @@ requirements:
     - xorg-xorgproto  # [linux]
     - xorg-libxtst  # [linux]
     - zlib
-    - libtree-sitter 0.24.*  # https://github.com/conda-forge/libtree-sitter-feedstock/issues/25
+    - libtree-sitter
     - jansson
 
   run:
@@ -129,7 +129,7 @@ requirements:
     - xorg-xorgproto  # [linux]
     - xorg-libxtst  # [linux]
     - zlib
-    - libtree-sitter 0.24.*  # https://github.com/conda-forge/libtree-sitter-feedstock/issues/25
+    - libtree-sitter
     - jansson
 
 test:


### PR DESCRIPTION
libtree-sitter feedstock 0.25.2 is now fixed

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
