### PR TITLE
Avoid using deprecated malloc_set_state on Linux

### DIFF
--- a/recipe/0009-disable-malloc-set-state.patch
+++ b/recipe/0009-disable-malloc-set-state.patch
@@ -1,0 +1,24 @@
+diff -u emacs-30.0.93.orig/configure emacs-30.0.93/configure
+--- emacs-30.0.93.orig/configure	2024-12-19 16:32:49.000000000 -0500
++++ emacs-30.0.93/configure	2025-01-26 04:13:32.715499727 -0500
+@@ -16848,7 +16848,7 @@
+ fi
+ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $emacs_cv_var_doug_lea_malloc" >&5
+ printf "%s\n" "$emacs_cv_var_doug_lea_malloc" >&6; }
+-doug_lea_malloc=$emacs_cv_var_doug_lea_malloc
++doug_lea_malloc=no
+ 
+ hybrid_malloc=
+ system_malloc=yes
+diff -u emacs-30.0.93.orig/configure.ac emacs-30.0.93/configure.ac
+--- emacs-30.0.93.orig/configure.ac	2024-12-19 16:27:30.000000000 -0500
++++ emacs-30.0.93/configure.ac	2025-01-26 04:13:14.381360608 -0500
+@@ -3314,7 +3314,7 @@
+ 	    __malloc_initialize_hook = hook;]])],
+        [emacs_cv_var_doug_lea_malloc=yes])
+    fi])
+-doug_lea_malloc=$emacs_cv_var_doug_lea_malloc
++doug_lea_malloc=no
+ 
+ hybrid_malloc=
+ system_malloc=yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,13 +22,14 @@ source:
       - 0006-macos-cross-compile-post-install-pdump-path.patch  # [osx and build_platform != target_platform]
       - 0007-macos-cross-compile-lisp-makefile.patch  # [osx and build_platform != target_platform]
       - 0008-do-not-dump-configure-info-directory.patch  # [linux]
+      - 0009-disable-malloc-set-state.patch  # [linux]
   - fn: gcc-{{ gcc_version }}.tar.xz  # [linux]
     url: https://ftp.gnu.org/gnu/gcc/gcc-{{ gcc_version }}/gcc-{{ gcc_version }}.tar.xz  # [linux]
     sha256: a7b39bc69cbf9e25826c5a60ab26477001f7c08d85cec04bc0e29cabed6f3cc9  # [linux]
     folder: gcc  # [linux]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   ignore_prefix_files:
     - lib/emacs/jit/bin/*


### PR DESCRIPTION
malloc_set_state is not available in recent glibc versions.

Disable the DOUG_LEA_MALLOC flag to avoid its usage.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
