### PR TITLE
Pin libtree-sitter to 0.25

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,7 @@
 context:
   version: 30.2
   gcc_version: 14.3.0
+  tree_sitter_version: 0.25.*
 
 package:
   name: emacs
@@ -34,7 +35,7 @@ source:
         target_directory: gcc
 
 build:
-  number: 1
+  number: 2
   skip: win
   files:
     exclude:
@@ -81,7 +82,7 @@ requirements:
         - libpng
         - librsvg
         - libtiff
-        - libtree-sitter
+        - libtree-sitter ${{ tree_sitter_version }}
         - libxml2
         - ncurses
         - zlib
@@ -119,7 +120,7 @@ requirements:
     - libpng
     - librsvg
     - libtiff
-    - libtree-sitter
+    - libtree-sitter ${{ tree_sitter_version }}
     - libxml2
     - ncurses
     - zlib


### PR DESCRIPTION
libtree-sitter 0.26 is incompatible with current emacs

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
